### PR TITLE
バグフィックス

### DIFF
--- a/src/ocv_test/ocv_test/UI/include/ui_input_result.h
+++ b/src/ocv_test/ocv_test/UI/include/ui_input_result.h
@@ -111,6 +111,8 @@ typedef struct{
 typedef struct{
     cv::Mat mat;
     cv::Mat mat_aft;
+    IplImage *img;
+    IplImage *img_aft;
     const char *img_name;
     const char *img_name2;
 }ocv_param;

--- a/src/ocv_test/ocv_test/UI/src/ui_menu.cpp
+++ b/src/ocv_test/ocv_test/UI/src/ui_menu.cpp
@@ -75,8 +75,6 @@ menu_file_save( eMenuParam *menu_param )
 static bool
 menu_color_chg_mono( eMenuParam *menu_param )
 {
-    printf( "%s() not implemented\n", __func__ );
-
     static eMENU_INPUT_RESULT_COLOR_CHG_MONO input_param;
     menu_param->menu_id = eMENU_COLOR_CHG_MONO;
     menu_param->input_param = &input_param;
@@ -285,15 +283,15 @@ print_menu( void)
 
         "[回転]\n"
         " - 操作 -         : - 入力値 -\n"
-        " 右回転           : 2001\n"
-        " 左回転           : 2002\n"
+        " 右回転           : 2000\n"
+        " 左回転           : 2001\n"
         "\n"
 
         "[変形]\n"
         " - 操作 -         : - 入力値 -\n"
-        " 拡大             : 3001\n"
-        " 縮小             : 3002\n"
-        " リサイズ         : 3003\n"
+        " 拡大             : 3000\n"
+        " 縮小             : 3001\n"
+        " リサイズ         : 3002\n"
         "\n"
 
         "[その他]\n"
@@ -308,11 +306,8 @@ print_menu( void)
 void
 UI_menu_main( eMenuParam *menu_param )
 {
-    const int BUFFER_SIZE = 256;
-
     bool menu_result = false;
-    bool input_end = false;
-    char input_char;
+    int input_char;
     char buf[ BUFFER_SIZE ];
     while( menu_result == false )
     {

--- a/src/ocv_test/ocv_test/ocv/src/ocv_main.cpp
+++ b/src/ocv_test/ocv_test/ocv/src/ocv_main.cpp
@@ -15,14 +15,14 @@ ocv_file_open( eMenuParam *param )
 {
     auto p = ( eMENU_INPUT_RESULT_FILE_OPEN* )param->input_param;
 
-    param->ocv_param.mat = imread( p->filename, CV_LOAD_IMAGE_COLOR );
-    if( param->ocv_param.mat.data == 0 )
+    param->ocv_param.img = cvLoadImage( p->filename, CV_LOAD_IMAGE_COLOR );
+    if( param->ocv_param.img == NULL )
     {
         printf( "%sの読み込みに失敗しました。ファイルの有無を確認して下さい\n", p->filename );
         return;
     }
-    namedWindow( param->ocv_param.img_name, CV_WINDOW_AUTOSIZE );
-    imshow( param->ocv_param.img_name, param->ocv_param.mat );
+    cvNamedWindow( param->ocv_param.img_name, CV_WINDOW_AUTOSIZE );
+    cvShowImage( param->ocv_param.img_name, param->ocv_param.img );
     waitKey( 1 ); // 再描画を促す
 }
 
@@ -39,7 +39,8 @@ ocv_file_save( eMenuParam *param )
 {
     auto p = ( eMENU_INPUT_RESULT_FILE_SAVE* )param->input_param;
 
-    imwrite( p->filename, param->ocv_param.mat );
+    cvSaveImage( p->filename, param->ocv_param.img );
+    printf( "%sとして保存しました\n", p->filename );
 }
 
 /**
@@ -50,19 +51,62 @@ ocv_color_change_mono( eMenuParam *param )
 {
     auto p = ( eMENU_INPUT_RESULT_COLOR_CHG_MONO* )param->input_param;
 
-    Mat img_aft;
-    cvtColor( param->ocv_param.mat, img_aft, COLOR_RGB2GRAY );
-    imshow( param->ocv_param.img_name, img_aft );
+    IplImage *img_gray = cvCreateImage( cvGetSize( param->ocv_param.img ), IPL_DEPTH_8U, 1 );
+    IplImage *img_aft = cvCreateImage( cvGetSize( param->ocv_param.img ), IPL_DEPTH_8U, 3 );
+    cvCvtColor( param->ocv_param.img, img_gray, CV_BGR2GRAY );
+    cvMerge( img_gray, img_gray, img_gray, NULL, img_aft );
+    cvReleaseImage( &img_gray );
+
+    cvShowImage( param->ocv_param.img_name, img_aft );
     waitKey( 1 ); // 再描画を促す
-    param->ocv_param.mat = img_aft;
+    cvReleaseImage( &param->ocv_param.img );
+    param->ocv_param.img = img_aft;
 }
 
 static void
 ocv_color_change_sepia( eMenuParam *param )
 {
+    const int sepia_hue = 22;
+    const int sepia_sat = 90;
+
     auto p = ( eMENU_INPUT_RESULT_COLOR_CHG_SEPIA* )param->input_param;
 
-    printf( "%s() not implemented\n", __func__ );
+    CvSize img_size = cvGetSize( param->ocv_param.img );
+
+    //	画像を生成する
+    IplImage *img_HSV = cvCreateImage( img_size, IPL_DEPTH_8U, 3 ); // HSV画像
+    IplImage *img_hue = cvCreateImage( img_size, IPL_DEPTH_8U, 1 ); // 色相(H)
+    IplImage *img_sat = cvCreateImage( img_size, IPL_DEPTH_8U, 1 ); // 彩度(S)
+    IplImage *img_val = cvCreateImage( img_size, IPL_DEPTH_8U, 1 ); // 明度(V)
+
+    IplImage *img_merge = cvCreateImage( img_size, IPL_DEPTH_8U, 3 ); // for merge
+    IplImage *img_aft = cvCreateImage( img_size, IPL_DEPTH_8U, 3 );
+
+    CvScalar cv_value_hue = cvScalar( sepia_hue );
+    CvScalar cv_value_sat = cvScalar( sepia_sat );
+
+    // 表色系変換( BGR -> HSV )
+    cvCvtColor( param->ocv_param.img, img_HSV, CV_BGR2HSV );
+
+    // HSV画像 -> [Hue][Sat][Val]分解
+    cvSplit( img_HSV, img_hue, img_sat, img_val, NULL );
+    cvReleaseImage( &img_HSV );
+
+    cvSet( img_hue, cv_value_hue, NULL ); // Hueの値をセピア用の値へ
+    cvSet( img_sat, cv_value_sat, NULL ); // Satの値をセピア用の値へ
+
+    // [Hue][Sat][Val] => img_mergeとして統合
+    cvMerge( img_hue, img_sat, img_val, NULL, img_merge );
+    cvReleaseImage( &img_hue );
+    cvReleaseImage( &img_sat );
+    cvReleaseImage( &img_val );
+
+    //	HSVからBGRに変換する
+    cvCvtColor( img_merge, img_aft, CV_HSV2BGR );
+    cvReleaseImage( &img_merge );
+    cvShowImage( param->ocv_param.img_name, img_aft );
+    cvWaitKey( 1 );
+    param->ocv_param.img = img_aft;
 }
 
 /**
@@ -141,6 +185,7 @@ ocv_trim( eMenuParam *param )
 static void
 OCV_Demo( eMenuParam *param )
 {
+    param; // warning C4100対策の有名なテクニック( 引数は関数の本体部で参照されません )
     IplImage *img_ptr = cvLoadImage( "red-panda-731987_960_720.jpg", CV_LOAD_IMAGE_COLOR );
     if( img_ptr == nullptr )
     {
@@ -163,6 +208,7 @@ OCV_Demo( eMenuParam *param )
 static void
 OCV_Unknown( eMenuParam *param )
 {
+    param; // warning C4100対策の有名なテクニック( 引数は関数の本体部で参照されません )
     assert( 0 );
 }
 

--- a/src/ocv_test/ocv_test/ocv_test.vcxproj
+++ b/src/ocv_test/ocv_test/ocv_test.vcxproj
@@ -85,13 +85,13 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>C:\devel\library\open_cv\3.4.1\build\include;$(ProjectDir)\ui\include;$(ProjectDir)\mode\include;$(ProjectDir)\ocv\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\devel\library\open_cv\3.4.1\build\include;$(ProjectDir)\ui\include;$(ProjectDir)\mode\include;$(ProjectDir)\ocv\include;$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -104,13 +104,13 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>C:\devel\library\open_cv\3.4.1\build\include;$(ProjectDir)\ui\include;$(ProjectDir)\mode\include;$(ProjectDir)\ocv\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\devel\library\open_cv\3.4.1\build\include;$(ProjectDir)\ui\include;$(ProjectDir)\mode\include;$(ProjectDir)\ocv\include;$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -123,7 +123,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -131,7 +131,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>C:\devel\library\open_cv\3.4.1\build\include;$(ProjectDir)\ui\include;$(ProjectDir)\mode\include;$(ProjectDir)\ocv\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\devel\library\open_cv\3.4.1\build\include;$(ProjectDir)\ui\include;$(ProjectDir)\mode\include;$(ProjectDir)\ocv\include;$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -146,7 +146,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -154,7 +154,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>C:\devel\library\open_cv\3.4.1\build\include;$(ProjectDir)\ui\include;$(ProjectDir)\mode\include;$(ProjectDir)\ocv\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\devel\library\open_cv\3.4.1\build\include;$(ProjectDir)\ui\include;$(ProjectDir)\mode\include;$(ProjectDir)\ocv\include;$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>

--- a/src/ocv_test/ocv_test/pch.h
+++ b/src/ocv_test/ocv_test/pch.h
@@ -12,5 +12,7 @@
 // TODO: ここでプリコンパイルするヘッダーを追加します
 // OpenCV
 #include <opencv2/opencv.hpp>
+#include <cstdio>
+#include <cstdlib>
 
 #endif //PCH_H


### PR DESCRIPTION
モノクロ/セピア処理のバグ修正
OpenCV1.xと2系が混在していたのを1.x系へ統一( OpenCV2は後日対応予定  )
警告レベルを3から4へ上げる